### PR TITLE
replace np.float with float, related to #80

### DIFF
--- a/easyidp/metashape.py
+++ b/easyidp/metashape.py
@@ -1317,10 +1317,10 @@ def _decode_chunk_transform_tag(xml_obj):
     """
     transform = idp.reconstruct.ChunkTransform()
     chunk_rotation_str = xml_obj.findall("./rotation")[0].text
-    transform.rotation = np.fromstring(chunk_rotation_str, sep=" ", dtype=np.float).reshape((3, 3))
+    transform.rotation = np.fromstring(chunk_rotation_str, sep=" ", dtype=float).reshape((3, 3))
 
     chunk_translation_str = xml_obj.findall("./translation")[0].text
-    transform.translation = np.fromstring(chunk_translation_str, sep=" ", dtype=np.float)
+    transform.translation = np.fromstring(chunk_translation_str, sep=" ", dtype=float)
 
     transform.scale = float(xml_obj.findall("./scale")[0].text)
 
@@ -1648,7 +1648,7 @@ def _decode_camera_tag(xml_obj):
     transform_tag = xml_obj.findall("./transform")
     if len(transform_tag) == 1:
         transform_str = transform_tag[0].text
-        camera.transform = np.fromstring(transform_str, sep=" ", dtype=np.float).reshape((4, 4))
+        camera.transform = np.fromstring(transform_str, sep=" ", dtype=float).reshape((4, 4))
     else:
         # have no transform, can not do the reverse caluclation
         camera.enabled = False
@@ -1656,12 +1656,12 @@ def _decode_camera_tag(xml_obj):
     shutter_rotation_tag = xml_obj.findall("./rolling_shutter/rotation")
     if len(shutter_rotation_tag) == 1:
         shutter_rotation_str = shutter_rotation_tag[0].text
-        camera.rotation = np.fromstring(shutter_rotation_str, sep=" ", dtype=np.float).reshape((3, 3))
+        camera.rotation = np.fromstring(shutter_rotation_str, sep=" ", dtype=float).reshape((3, 3))
 
     shutter_translation_tag = xml_obj.findall("./rolling_shutter/translation")
     if len(shutter_translation_tag) == 1:
         shutter_translation_str = shutter_translation_tag[0].text
-        camera.translation = np.fromstring(shutter_translation_str, sep=" ", dtype=np.float)
+        camera.translation = np.fromstring(shutter_translation_str, sep=" ", dtype=float)
 
     return camera
 

--- a/easyidp/pix4d.py
+++ b/easyidp/pix4d.py
@@ -1456,7 +1456,7 @@ def read_pmat(pmat_path):
         }
 
     """
-    pmat_nb = np.loadtxt(pmat_path, dtype=np.float, delimiter=None, usecols=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,))
+    pmat_nb = np.loadtxt(pmat_path, dtype=float, delimiter=None, usecols=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,))
     pmat_names = np.loadtxt(pmat_path, dtype=str, delimiter=None, usecols=0)
 
     pmat_dict = {}
@@ -1692,24 +1692,24 @@ def read_ccp(ccp_path):
                 img_configs['w'] = int(w)
                 img_configs['h'] = int(h)
             elif block_id == 2:
-                cam_mat_line1 = np.fromstring(line, dtype=np.float, sep=' ')
+                cam_mat_line1 = np.fromstring(line, dtype=float, sep=' ')
             elif block_id == 3:
-                cam_mat_line2 = np.fromstring(line, dtype=np.float, sep=' ')
+                cam_mat_line2 = np.fromstring(line, dtype=float, sep=' ')
             elif block_id == 4:
-                cam_mat_line3 = np.fromstring(line, dtype=np.float, sep=' ')
+                cam_mat_line3 = np.fromstring(line, dtype=float, sep=' ')
                 img_configs[file_name]['cam_matrix'] = np.vstack([cam_mat_line1, cam_mat_line2, cam_mat_line3])
             elif block_id == 5:
-                img_configs[file_name]['rad_distort'] = np.fromstring(line, dtype=np.float, sep=' ')
+                img_configs[file_name]['rad_distort'] = np.fromstring(line, dtype=float, sep=' ')
             elif block_id == 6:
-                img_configs[file_name]['tan_distort'] = np.fromstring(line, dtype=np.float, sep=' ')
+                img_configs[file_name]['tan_distort'] = np.fromstring(line, dtype=float, sep=' ')
             elif block_id == 7:
-                img_configs[file_name]['cam_pos'] = np.fromstring(line, dtype=np.float, sep=' ')
+                img_configs[file_name]['cam_pos'] = np.fromstring(line, dtype=float, sep=' ')
             elif block_id == 8:
-                cam_rot_line1 = np.fromstring(line, dtype=np.float, sep=' ')
+                cam_rot_line1 = np.fromstring(line, dtype=float, sep=' ')
             elif block_id == 9:
-                cam_rot_line2 = np.fromstring(line, dtype=np.float, sep=' ')
+                cam_rot_line2 = np.fromstring(line, dtype=float, sep=' ')
             elif block_id == 0:
-                cam_rot_line3 = np.fromstring(line, dtype=np.float, sep=' ')
+                cam_rot_line3 = np.fromstring(line, dtype=float, sep=' ')
                 cam_rot = np.vstack([cam_rot_line1, cam_rot_line2, cam_rot_line3])
                 img_configs[file_name]['cam_rot'] = cam_rot
 
@@ -1787,7 +1787,7 @@ def read_campos_geo(campos_path):
         for line in f.readlines():
             sp_list = line.split(',')
             if len(sp_list) == 4: 
-                cam_dict[sp_list[0]] = np.array(sp_list[1:], dtype=np.float)
+                cam_dict[sp_list[0]] = np.array(sp_list[1:], dtype=float)
 
     return cam_dict
 

--- a/tests/test_metashape.py
+++ b/tests/test_metashape.py
@@ -17,10 +17,10 @@ def test_apply_transform_matrix():
         [-0.86573098, -0.01489186,  0.08977677,  7.65034123],
         [ 0.06972335,  0.44334391,  0.74589315,  1.85910928],
         [-0.05848325,  0.74899678, -0.43972184, -0.1835615],
-        [ 0.,          0.,          0.,          1.]], dtype=np.float)
+        [ 0.,          0.,          0.,          1.]], dtype=float)
     matrix2 = np.linalg.inv(matrix)
 
-    point1 = np.array([0.5, 1, 1.5], dtype=np.float)
+    point1 = np.array([0.5, 1, 1.5], dtype=float)
     out1 = idp.metashape.apply_transform_matrix(point1, matrix2)
 
     ans1 = np.array([7.96006409,  1.30195288, -2.66971818])
@@ -28,7 +28,7 @@ def test_apply_transform_matrix():
 
     np_array = np.array([
         [0.5, 1, 1.5],
-        [0.5, 1, 1.5]], dtype=np.float)
+        [0.5, 1, 1.5]], dtype=float)
     out2 = idp.metashape.apply_transform_matrix(np_array, matrix2)
     ans2 = np.array([
         [7.96006409, 1.30195288, -2.66971818],
@@ -279,7 +279,7 @@ def test_local2world2local():
         [-0.86573098, -0.01489186,  0.08977677,  7.65034123],
         [ 0.06972335,  0.44334391,  0.74589315,  1.85910928],
         [-0.05848325,  0.74899678, -0.43972184, -0.1835615],
-        [ 0.,          0.,          0.,           1.]], dtype=np.float)
+        [ 0.,          0.,          0.,           1.]], dtype=float)
     w_pos = np.array([0.5, 1, 1.5])
     l_pos = np.array(
         [7.960064093299587, 1.3019528769064523, -2.6697181763370965]


### PR DESCRIPTION
Tests were failing with latest numpy version. Related to #80. 
I replaced all np.float with float. If you want np.float64 I can do that too.

Tested on numpy 1.24.2
1.24.2

pytest passes, except for a missing file

```
(BirdDetector) benweinstein@Bens-MacBook-Pro EasyIDP % pytest
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/benweinstein/Documents/EasyIDP
collected 136 items

tests/test_cvtools.py ........                                                                                                                                                                                                                         [  5%]
tests/test_data.py ...                                                                                                                                                                                                                                 [  8%]
tests/test_geotiff.py .....................                                                                                                                                                                                                            [ 23%]
tests/test_init_class_func.py .....                                                                                                                                                                                                                    [ 27%]
tests/test_jsonfile.py ..                                                                                                                                                                                                                              [ 28%]
tests/test_metashape.py ....F.............                                                                                                                                                                                                             [ 41%]
tests/test_pix4d.py ..............                                                                                                                                                                                                                     [ 52%]
tests/test_pointcloud.py ........................                                                                                                                                                                                                      [ 69%]
tests/test_reconstruct.py ........                                                                                                                                                                                                                     [ 75%]
tests/test_roi.py .................                                                                                                                                                                                                                    [ 88%]
tests/test_shp.py ............                                                                                                                                                                                                                         [ 97%]
tests/test_visualize.py ....                                                                                                                                                                                                                           [100%]

========================================================================================================================== FAILURES ==========================================================================================================================
___________________________________________________________________________________________________________ test_class_init_metashape_multi_folder ___________________________________________________________________________________________________________

    def test_class_init_metashape_multi_folder():
        ms = idp.Metashape(project_path=test_data.metashape.multifolder_psx, chunk_id=0)

        assert ms.photos[0].label == "100MEDIA-DJI_0003"
        assert "100MEDIA/DJI_0003" in ms.photos[0].path

        # test run reverse calcuation
        # 1/30 size of square in the center of the full plot
        # export the chunk to aaa.ply, and read by open3d
        #
        # In [2]: pts = o3d.io.read_point_cloud("/Users/hwang/Desktop/aaa.ply")
        # In [4]: points = np.array(pts.points)
        # In [8]: xmin, ymin, z_min = points.min(axis=0)
        # In [9]: xmax, ymax, z_max = points.max(axis=0)
        # In [10]: xmean, ymean, z_mean = points.mean(axis=0)
        # In [11]: xlen = xmax- xmin
        # In [12]: ylen = ymax-ymin
        #
        # In [13]: xlen
        # Out[13]: 0.0045318603515625
        # In [26]: bf = xlen/30
        # In [27]: x0 = xmean - bf
        # In [28]: y0 = ymean -bf
        # In [29]: x1 = xmean + bf
        # In [30]: y1 = ymean + bf
        # In [31]: roi = np.array([[x0, y0, z0],[x0, y1, z0],[x1,y1,z0],[x1,y0,z0],[x0,y0,
        #     ...: z0]])
        # In [32]: roi
        # Out[32]:
        # array([[-120.87534231,   39.50387817, 1441.56202452],
        #        [-120.87534231,   39.50418029, 1441.56202452],
        #        [-120.87504018,   39.50418029, 1441.56202452],
        #        [-120.87504018,   39.50387817, 1441.56202452],
        #        [-120.87534231,   39.50387817, 1441.56202452]])

        roi = np.array(
            [[-120.87534231,   39.50387817, 1441.56202452],
             [-120.87534231,   39.50418029, 1441.56202452],
             [-120.87504018,   39.50418029, 1441.56202452],
             [-120.87504018,   39.50387817, 1441.56202452],
             [-120.87534231,   39.50387817, 1441.56202452]])

        out = ms.back2raw_crs(roi)

        assert len(out) == 40
        assert "100MEDIA-DJI_0099" in out.keys()

        # test_class_init_metashape_nested_folder
>       ms = idp.Metashape(project_path=test_data.metashape.nestedfolder_psx, chunk_id=0)

tests/test_metashape.py:148:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
easyidp/metashape.py:107: in __init__
    self.open_project(project_path, chunk_id)
easyidp/metashape.py:173: in open_project
    self._open_whole_project(project_path)
easyidp/metashape.py:264: in _open_whole_project
    _check_is_software(project_path)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

path = PosixPath('/Users/benweinstein/Library/Application Support/easyidp.data/data_for_tests/metashape/nestedfolders.psx')

    def _check_is_software(path: str):
        """Check if given path is metashape project structure

        Parameters
        ----------
        path: str
            e.g. proj_path="/root/to/metashape/test_proj.psx"

        Returns
        -------
        raise error if not a metashape projects (missing some files or path not found)
        """
        if not os.path.exists(path):
>           raise FileNotFoundError(f"Could not find Metashape project file [{path}]")
E           FileNotFoundError: Could not find Metashape project file [/Users/benweinstein/Library/Application Support/easyidp.data/data_for_tests/metashape/nestedfolders.psx]

easyidp/metashape.py:1266: FileNotFoundError
====================================================================================================================== warnings summary ======================================================================================================================
tests/test_metashape.py:428
  /Users/benweinstein/Documents/EasyIDP/tests/test_metashape.py:428: DeprecationWarning: invalid escape sequence \O
    '''

tests/test_cvtools.py::test_poly2mask_type_int
tests/test_cvtools.py::test_poly2mask_type_float
  /Users/benweinstein/Documents/EasyIDP/./easyidp/cvtools.py:275: ShapelyDeprecationWarning: The array interface is deprecated and will no longer work in Shapely 2.0. Convert the '.coords' to a numpy array instead.
    mask = _shapely_poly2mask(h, w, poly_coord)

tests/test_metashape.py::test_class_init_metashape
tests/test_metashape.py::test_class_init_metashape_warns_errors
tests/test_metashape.py::test_class_show_chunk
tests/test_metashape.py::test_class_back2raw_error
tests/test_roi.py::test_class_roi_back2raw_error
  /Users/benweinstein/Documents/EasyIDP/./easyidp/metashape.py:297: UserWarning: This project only has one chunk named [0] 'Chunk 1', ignore the wrong chunk_id [None] specified by user.
    warnings.warn(

tests/test_metashape.py::test_class_init_metashape_multi_folder
  /Users/benweinstein/Documents/EasyIDP/./easyidp/metashape.py:509: UserWarning: Have not specify the CRS of output DOM/DSM/PCD, may get wrong backward projection results, please specify it by `ms.crs=dom.crs` or `ms.crs=pyproj.CRS.from_epsg(...)`
    warnings.warn("Have not specify the CRS of output DOM/DSM/PCD, may get wrong backward projection results, please specify it by `ms.crs=dom.crs` or `ms.crs=pyproj.CRS.from_epsg(...)` ")

tests/test_metashape.py::test_class_init_metashape_warns_errors
  /Users/benweinstein/Documents/EasyIDP/./easyidp/metashape.py:304: UserWarning: The project has [4] chunks, however no chunk_id has been specified, open the first chunk [1] 'multiple_bbb' by default.
    warnings.warn(

tests/test_metashape.py::test_class_init_metashape_warns_errors
tests/test_metashape.py::test_class_show_chunk
tests/test_metashape.py::test_class_open_chunk_print
  /Users/benweinstein/Documents/EasyIDP/./easyidp/metashape.py:344: UserWarning: Current chunk missing required ['transform', 'sensors', 'photos'] information (is it an empty chunk without finishing SfM tasks?) and unable to do further analysis.
    warnings.warn(f"Current chunk missing required {missing_pool} information "

tests/test_pix4d.py::test_class_read_renamed_project
tests/test_pix4d.py::test_class_back2raw_single
tests/test_pix4d.py::test_class_back2raw_error
tests/test_pix4d.py::test_class_photos_get_by_short_name
tests/test_visualize.py::test_class_back2raw_single
  /Users/benweinstein/Documents/EasyIDP/./easyidp/pix4d.py:302: UserWarning: Could not find ['DJI_0151.JPG', 'DJI_0152.JPG', 'DJI_0153.JPG', 'DJI_0154.JPG', 'DJI_0155.JPG', 'DJI_0156.JPG', 'DJI_0157.JPG', 'DJI_0158.JPG', 'DJI_0159.JPG', 'DJI_0160.JPG', 'DJI_0161.JPG', 'DJI_0162.JPG', 'DJI_0163.JPG', 'DJI_0164.JPG', 'DJI_0166.JPG', 'DJI_0167.JPG', 'DJI_0170.JPG', 'DJI_0171.JPG', 'DJI_0172.JPG', 'DJI_0173.JPG', 'DJI_0175.JPG', 'DJI_0176.JPG', 'DJI_0177.JPG', 'DJI_0178.JPG', 'DJI_0179.JPG', 'DJI_0180.JPG', 'DJI_0181.JPG', 'DJI_0182.JPG', 'DJI_0183.JPG', 'DJI_0184.JPG', 'DJI_0185.JPG', 'DJI_0186.JPG', 'DJI_0187.JPG', 'DJI_0188.JPG', 'DJI_0189.JPG', 'DJI_0190.JPG', 'DJI_0191.JPG', 'DJI_0192.JPG', 'DJI_0193.JPG', 'DJI_0194.JPG', 'DJI_0195.JPG', 'DJI_0196.JPG', 'DJI_0202.JPG', 'DJI_0203.JPG', 'DJI_0204.JPG', 'DJI_0205.JPG', 'DJI_0206.JPG', 'DJI_0207.JPG', 'DJI_0208.JPG', 'DJI_0209.JPG', 'DJI_0210.JPG', 'DJI_0211.JPG', 'DJI_0212.JPG', 'DJI_0213.JPG', 'DJI_0214.JPG', 'DJI_0215.JPG', 'DJI_0216.JPG', 'DJI_0217.JPG', 'DJI_0218.JPG', 'DJI_0219.JPG', 'DJI_0220.JPG', 'DJI_0221.JPG', 'DJI_0222.JPG', 'DJI_0223.JPG', 'DJI_0224.JPG', 'DJI_0225.JPG', 'DJI_0226.JPG', 'DJI_0232.JPG', 'DJI_0233.JPG', 'DJI_0234.JPG', 'DJI_0235.JPG', 'DJI_0236.JPG', 'DJI_0237.JPG', 'DJI_0238.JPG', 'DJI_0239.JPG', 'DJI_0240.JPG', 'DJI_0241.JPG', 'DJI_0242.JPG', 'DJI_0243.JPG', 'DJI_0244.JPG', 'DJI_0245.JPG', 'DJI_0246.JPG', 'DJI_0247.JPG', 'DJI_0248.JPG', 'DJI_0249.JPG', 'DJI_0250.JPG', 'DJI_0252.JPG', 'DJI_0253.JPG', 'DJI_0254.JPG', 'DJI_0255.JPG', 'DJI_0256.JPG', 'DJI_0257.JPG', 'DJI_0258.JPG', 'DJI_0259.JPG', 'DJI_0260.JPG', 'DJI_0261.JPG', 'DJI_0262.JPG', 'DJI_0263.JPG', 'DJI_0264.JPG', 'DJI_0265.JPG', 'DJI_0266.JPG', 'DJI_0267.JPG', 'DJI_0268.JPG', 'DJI_0269.JPG', 'DJI_0270.JPG', 'DJI_0271.JPG', 'DJI_0272.JPG', 'DJI_0273.JPG', 'DJI_0274.JPG', 'DJI_0275.JPG', 'DJI_0276.JPG', 'DJI_0277.JPG', 'DJI_0278.JPG', 'DJI_0279.JPG', 'DJI_0280.JPG', 'DJI_0281.JPG', 'DJI_0282.JPG', 'DJI_0283.JPG', 'DJI_0284.JPG', 'DJI_0285.JPG', 'DJI_0286.JPG', 'DJI_0287.JPG', 'DJI_0288.JPG', 'DJI_0289.JPG', 'DJI_0290.JPG', 'DJI_0291.JPG', 'DJI_0292.JPG', 'DJI_0293.JPG', 'DJI_0294.JPG', 'DJI_0295.JPG', 'DJI_0296.JPG', 'DJI_0297.JPG', 'DJI_0298.JPG', 'DJI_0299.JPG', 'DJI_0300.JPG', 'DJI_0301.JPG', 'DJI_0302.JPG', 'DJI_0303.JPG', 'DJI_0304.JPG', 'DJI_0305.JPG', 'DJI_0306.JPG', 'DJI_0307.JPG', 'DJI_0308.JPG', 'DJI_0309.JPG', 'DJI_0310.JPG', 'DJI_0311.JPG', 'DJI_0312.JPG', 'DJI_0313.JPG', 'DJI_0314.JPG', 'DJI_0315.JPG', 'DJI_0316.JPG', 'DJI_0317.JPG', 'DJI_0318.JPG', 'DJI_0319.JPG', 'DJI_0320.JPG', 'DJI_0321.JPG', 'DJI_0322.JPG', 'DJI_0323.JPG', 'DJI_0324.JPG', 'DJI_0325.JPG', 'DJI_0326.JPG', 'DJI_0327.JPG', 'DJI_0328.JPG', 'DJI_0329.JPG', 'DJI_0330.JPG', 'DJI_0331.JPG', 'DJI_0332.JPG', 'DJI_0333.JPG', 'DJI_0334.JPG', 'DJI_0335.JPG', 'DJI_0336.JPG', 'DJI_0337.JPG', 'DJI_0338.JPG', 'DJI_0339.JPG', 'DJI_0340.JPG', 'DJI_0341.JPG', 'DJI_0342.JPG', 'DJI_0343.JPG', 'DJI_0344.JPG', 'DJI_0345.JPG', 'DJI_0346.JPG', 'DJI_0347.JPG', 'DJI_0348.JPG', 'DJI_0349.JPG', 'DJI_0350.JPG', 'DJI_0351.JPG', 'DJI_0352.JPG', 'DJI_0353.JPG', 'DJI_0354.JPG', 'DJI_0355.JPG', 'DJI_0356.JPG', 'DJI_0357.JPG', 'DJI_0358.JPG', 'DJI_0359.JPG', 'DJI_0360.JPG', 'DJI_0361.JPG', 'DJI_0362.JPG', 'DJI_0363.JPG', 'DJI_0364.JPG', 'DJI_0365.JPG', 'DJI_0366.JPG', 'DJI_0367.JPG', 'DJI_0368.JPG', 'DJI_0369.JPG', 'DJI_0370.JPG', 'DJI_0371.JPG', 'DJI_0372.JPG', 'DJI_0373.JPG', 'DJI_0374.JPG', 'DJI_0375.JPG', 'DJI_0376.JPG', 'DJI_0377.JPG', 'DJI_0378.JPG', 'DJI_0379.JPG', 'DJI_0380.JPG', 'DJI_0381.JPG', 'DJI_0382.JPG', 'DJI_0383.JPG', 'DJI_0384.JPG', 'DJI_0385.JPG', 'DJI_0386.JPG', 'DJI_0387.JPG', 'DJI_0388.JPG', 'DJI_0389.JPG', 'DJI_0390.JPG', 'DJI_0391.JPG', 'DJI_0392.JPG', 'DJI_0393.JPG', 'DJI_0394.JPG', 'DJI_0395.JPG', 'DJI_0396.JPG', 'DJI_0397.JPG', 'DJI_0398.JPG', 'DJI_0399.JPG', 'DJI_0400.JPG', 'DJI_0401.JPG', 'DJI_0402.JPG', 'DJI_0403.JPG', 'DJI_0404.JPG', 'DJI_0405.JPG', 'DJI_0406.JPG', 'DJI_0407.JPG', 'DJI_0408.JPG', 'DJI_0409.JPG', 'DJI_0410.JPG', 'DJI_0411.JPG', 'DJI_0412.JPG', 'DJI_0413.JPG', 'DJI_0414.JPG', 'DJI_0415.JPG', 'DJI_0416.JPG', 'DJI_0417.JPG', 'DJI_0418.JPG', 'DJI_0419.JPG', 'DJI_0420.JPG', 'DJI_0421.JPG'] in given raw_img_folder[{raw_img_folder}]
    warnings.warn(

tests/test_reconstruct.py::test_class_sensor_in_img_boundary
  /Users/benweinstein/Documents/EasyIDP/./easyidp/reconstruct.py:231: FutureWarning: This API `ignore` (str) will be enhanced and changed to `ignore_overflow` (bool) in the future.
    warnings.warn(

tests/test_reconstruct.py::test_class_sensor_in_img_boundary
  /Users/benweinstein/Documents/EasyIDP/./easyidp/reconstruct.py:246: FutureWarning: This API `ignore` (str) will be enhanced and changed to `ignore_overflow` (bool) in the future.
    warnings.warn(

tests/test_roi.py::test_class_roi_change_crs
tests/test_roi.py::test_class_roi_get_z_from_dsm_errors
tests/test_shp.py::test_read_shp_without_target
tests/test_shp.py::test_read_shp_proj_success_print
tests/test_shp.py::test_read_shp_key_names
tests/test_shp.py::test_convert_shp
  /Users/benweinstein/Documents/EasyIDP/./easyidp/shp.py:399: UserWarning: Not specifying parameter 'name_field', will using the row id (from 0 to end) as the index for each polygon.Please using idp.shp.show_shp_field(shp_path) to display the full available indexs
    warnings.warn(

tests/test_roi.py::test_class_roi_crop
  /Users/benweinstein/Documents/EasyIDP/./easyidp/pointcloud.py:828: UserWarning: Cropped 0 point in given polygon. Please check whether the coords is correct.
    warnings.warn("Cropped 0 point in given polygon. Please check whether the coords is correct.")

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================================================================== short test summary info ===================================================================================================================
FAILED tests/test_metashape.py::test_class_init_metashape_multi_folder - FileNotFoundError: Could not find Metashape project file [/Users/benweinstein/Library/Application Support/easyidp.data/data_for_tests/metashape/nestedfolders.psx]
=================================================================================================== 1 failed, 135 passed, 27 warnings in 233.25s (0:03:53) =====================================================================================
```


```
FAILED tests/test_metashape.py::test_class_init_metashape_multi_folder - FileNotFoundError: Could not find Metashape project file [/Users/benweinstein/Library/Application Support/easyidp.data/data_for_tests/metashape/nestedfolders.psx]
```
Please consider making tests fully reproducible, then others can contribute more seemlessly. This is a great and important project that I hope the community can adopt. 

