### PR TITLE
docs: fix definitely spelling in docs

### DIFF
--- a/docs/python_api/reconstruct.rst
+++ b/docs/python_api/reconstruct.rst
@@ -23,7 +23,7 @@ A summary of base class in the module ``easyidp.reconstruct``.
     Calibration
     ChunkTransform
 
-You can definately access these base class directly by: 
+You can definitely access these base class directly by: 
 
 .. code-block:: python
 


### PR DESCRIPTION
Changes:
- `definately` -> `definitely` in `docs/python_api/reconstruct.rst` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
